### PR TITLE
feat(): Update tooltip style to match shadcn

### DIFF
--- a/src/shadcn/ui/tooltip.tsx
+++ b/src/shadcn/ui/tooltip.tsx
@@ -29,7 +29,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
    


### PR DESCRIPTION
Kept the text sizes the same but updated background colors to match shadcn examples
![Screenshot 2024-04-04 at 15 34 00](https://github.com/CQCL/quantinuum-ui/assets/20407539/bbe87a98-7d9f-4997-a8a6-fb91cdf6d08c)
![Screenshot 2024-04-04 at 15 31 50](https://github.com/CQCL/quantinuum-ui/assets/20407539/406d9b91-b3ad-4bd7-bb72-bc6749b20530)
