### PR TITLE
fix: fix destructive color opacity

### DIFF
--- a/src/tokens.css
+++ b/src/tokens.css
@@ -54,7 +54,7 @@
   --accent: 240 3.7% 15.9%;
   --accent-foreground: 0 0% 98%;
 
-  --destructive: 0, 84%, 60%;
+  --destructive: 0 84% 60%;
   --destructive-foreground: 240 10% 3.9%;
 
   --border: 240 3.7% 15.9%;


### PR DESCRIPTION
commas in the tokens cause the tailwind opacity to fail. Now hover events for destructive buttons works correctly.