### PR TITLE
fix(): update radio group styles

### DIFF
--- a/src/shadcn/ui/radio-group.tsx
+++ b/src/shadcn/ui/radio-group.tsx
@@ -1,10 +1,12 @@
 "use client"
 
 import * as React from "react"
-import { CheckIcon } from "@radix-ui/react-icons"
-import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+
 
 import { cn } from "src/utils"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { Circle } from "lucide-react"
+
 
 const RadioGroup = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Root>,
@@ -28,13 +30,13 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        "aspect-square h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}
     >
       <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-        <CheckIcon className="h-3.5 w-3.5 fill-primary" />
+        <Circle className="h-2.5 w-2.5 fill-current text-current" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   )


### PR DESCRIPTION
Update radio group styles to match shadcn. This now has better styled radio-group buttons, previously were checks which didn't match the styling as much and could be confused with a checkbox.
Updated styles:
![Screenshot 2024-07-09 at 09 35 27](https://github.com/CQCL/quantinuum-ui/assets/20407539/19501fed-6231-42f5-9bc8-d87df2c271f1)
![Screenshot 2024-07-09 at 09 35 11](https://github.com/CQCL/quantinuum-ui/assets/20407539/fc89ad6f-b387-49f0-aae5-9fafa01404fe)

