### PR TITLE
fix: Fix destructive color contrast in light theme

### DIFF
--- a/src/tokens.css
+++ b/src/tokens.css
@@ -21,7 +21,7 @@
   --accent: 240 4.8% 95.9%;
   --accent-foreground: 240 5.9% 10%;
 
-  --destructive: 0 84.2% 60.2%;
+  --destructive: 0 72.22% 50.59%;
   --destructive-foreground: 0 0% 98%;
 
   --border: 240 5.9% 90%;


### PR DESCRIPTION
The contrast ratio of destructive elements was weak.
![Screenshot 2024-07-10 at 15 47 38](https://github.com/CQCL/quantinuum-ui/assets/20407539/7f615678-ee50-49dd-a724-7e892ee79897)
![Screenshot 2024-07-10 at 15 44 56](https://github.com/CQCL/quantinuum-ui/assets/20407539/5018ff00-2afb-4a6d-91ac-9a024c7dc08d)

I have updated it using the colors from the tailwind color palette, from red.500 to red.600
![Screenshot 2024-07-10 at 15 47 17](https://github.com/CQCL/quantinuum-ui/assets/20407539/8b9daa06-2e98-4b50-96e9-6a28c41bdadf)
![Screenshot 2024-07-10 at 15 46 35](https://github.com/CQCL/quantinuum-ui/assets/20407539/e1949b53-c44a-46f1-9ae8-b997b2ef7753)
