### PR TITLE
chore: Define z levels

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,23 +1,30 @@
 import { Config } from "tailwindcss";
 import { tailwindTheme } from "./src";
 export default {
-    darkMode: ["class"],
-    content: ["./src/**/*.{ts,tsx}", "./stories/**/*.{ts,tsx}"],
+  darkMode: ["class"],
+  content: ["./src/**/*.{ts,tsx}", "./stories/**/*.{ts,tsx}"],
   presets: [tailwindTheme],
-    theme: {
-    	extend: {
-    		colors: {
-    			sidebar: {
-    				DEFAULT: 'hsl(var(--sidebar-background))',
-    				foreground: 'hsl(var(--sidebar-foreground))',
-    				primary: 'hsl(var(--sidebar-primary))',
-    				'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-    				accent: 'hsl(var(--sidebar-accent))',
-    				'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-    				border: 'hsl(var(--sidebar-border))',
-    				ring: 'hsl(var(--sidebar-ring))'
-    			}
-    		}
-    	}
-    }
+  theme: {
+    extend: {
+      colors: {
+        sidebar: {
+          DEFAULT: 'hsl(var(--sidebar-background))',
+          foreground: 'hsl(var(--sidebar-foreground))',
+          primary: 'hsl(var(--sidebar-primary))',
+          'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+          accent: 'hsl(var(--sidebar-accent))',
+          'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+          border: 'hsl(var(--sidebar-border))',
+          ring: 'hsl(var(--sidebar-ring))'
+        }
+      },
+      zIndex: {
+        navigation: '1',
+        tooltip: '100',
+        modal: '200',
+        loading: '300',
+        notification: '400',
+      },
+    },
+  }
 } satisfies Config;


### PR DESCRIPTION
In this PR:

I define z-levels. 
This will establish some rules that will make it clear what z-level should apply to the most commonly used elements.
*  navigation: '1', 
* tooltip: '100',
* modal: '200',
* loading: '300',
* notification: '400'

Tailwind classes will still work, and we should still use them. For example we will still need `z-0` or `z-auto` 
If we are to use another custom level, we should think twice if we really need it.

To use the above classes in your JSX/HTML `z-navigation` `z-tooltip` etc.