### PR TITLE
feat: Dark mode selector in storybook.

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,7 +3,7 @@
 
 <!-- Or you can load custom head-tag JavaScript: -->
 
- <script
+<script
   src="dist/src/utils/syncTheme.js"
   type="application/javascript"
 ></script>

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -10,6 +10,7 @@ const preview = {
       },
     },
   },
+
 };
 
 export default preview;

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm run build # Build component library with rollup.
 
 
 ### Design Tokens
-CSS variables are declared in `src/tokens.css`. Dark mode is enabled when using the attribute `data-theme="dark"` higher up in the DOM tree. See `src/tokens.css` for more details.
+CSS variables are declared in `src/tokens.css`. Dark mode is enabled when using the attribute `data-theme="dark"` on the root HTML element.
 
 
 

--- a/src/tokens.css
+++ b/src/tokens.css
@@ -40,7 +40,7 @@
   --sidebar-ring: 217.2 91.2% 59.8%;
 }
 
-:root [data-theme="dark"] {
+:root[data-theme="dark"] {
   color-scheme: dark;
   --background: 240 10% 7.9%;
   --foreground: 0 0% 98%;

--- a/src/utils/syncTheme.ts
+++ b/src/utils/syncTheme.ts
@@ -2,8 +2,8 @@ import { subscribeToTheme } from "./darkMode"
 
 // This script sets up event listeners to set the appropriate css class in the DOM for the current theme. It's intended to be executed in the head of the document hence it is immediately invoked (IIFE).
 (() =>  {
-   
+
     subscribeToTheme(({isDark}) => {
-        document.body.setAttribute("data-theme",  isDark ? "dark" : 'light') 
+        document.querySelector('html')?.setAttribute("data-theme",  isDark ? "dark" : 'light')
     })
 })()


### PR DESCRIPTION
Move data-theme attribute to root html element and fix associated css selector. 


https://github.com/user-attachments/assets/43bcd905-dec4-4222-97a4-9d0b2d61a9b8


