### PR TITLE
fix: Storybook dark mode script injection.

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -24,7 +24,7 @@ const config = {
     ${body}
     ${
        `<script
-        src="dist/src/utils/syncTheme.js"
+        src="/syncTheme.js"
         type="application/javascript"
       ></script>`
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "sideEffects": false,
   "scripts": {
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "rm -rf ./dist && rollup -c && storybook build && cp ./dist/src/utils/syncTheme.js ./storybook-static/syncTheme.js",
     "lint": "tsc",
     "build": "rm -rf ./dist && rollup -c"
   },


### PR DESCRIPTION
Adds syncTheme.js to storybook-static because dist isn't available.