### PR TITLE
feat: NRP 2575 - define custom breakpoints for QUUI

### DIFF
--- a/src/tailwindTheme.ts
+++ b/src/tailwindTheme.ts
@@ -8,7 +8,13 @@ export const tailwindTheme = {
       center: true,
       padding: "2rem",
       screens: {
-        "2xl": "1400px",
+        xs: '375px',
+        sm: '576px',
+        md: '768px',
+        lg: '1024px',
+        xl: '1280px',
+        '2xl': '1536px',
+        '3xl': '1920px',
       },
     },
     extend: {


### PR DESCRIPTION
In this PR:

* Defining custom breakpoints for QUUI
* A not-so-obvious change is that the `sm` breakpoint is being reduced from 640px to 576px. No breaking change detected.
* `2xl` probably is a leftover from the past, not sure why we have it set, does not seem to be used somewhere