### PR TITLE
chore: NRP-3269 Attempt to fix github ref to be main

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -57,5 +57,7 @@ jobs:
 
       - run: pnpm exec semantic-release
         env:
+          GITHUB_REF: refs/heads/${{ github.event.inputs.branch }}
+          GITHUB_REF_NAME: ${{ github.event.inputs.branch }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,3 +47,4 @@ For every additional trigger on the same branch, a new pre-release version is cr
 - Only maintainers with write access can trigger pre-releases.
 - The pre-release workflow also hard-fails if it is run from any branch other than `main`
 - The pre-release workflow also fetches full git history and `main` tags before publishing so semantic-release can correctly compare against `main`.
+- The pre-release workflow checks out the selected feature branch and runs semantic-release with that branch context.


### PR DESCRIPTION
### In this PR

I am getting an error ` The local branch main is behind the remote one, therefore a new version won't be published` and trying to fix it.

### Further info
What might happen is semantic-release reads GITHUB_REF_NAME=main, thinks it's releasing from main, it then checks if local main is up to date with remote main, finds it's behind, and aborts. 

I am overriding GITHUB_REF and GITHUB_REF_NAME to the feature branch, hoping that semantic-release will no longer evaluates main.