### PR TITLE
chore: ensure refs are forwarded to the component

### DIFF
--- a/src/shadcn/ui/input-group.tsx
+++ b/src/shadcn/ui/input-group.tsx
@@ -132,6 +132,7 @@ const InputGroupInput = React.forwardRef<HTMLInputElement, InputProps>(
   ({className, ...props}, ref) => {
     return (
       <Input
+        ref={ref}
         data-slot="input-group-control"
         className={cn(
           "flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",

--- a/src/shadcn/ui/tooltip.tsx
+++ b/src/shadcn/ui/tooltip.tsx
@@ -10,8 +10,9 @@ const TooltipProvider = TooltipPrimitive.Provider
 const Tooltip = React.forwardRef<
   React.ComponentRef<typeof TooltipPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>
->(({ ...props }) => (
+>(({ ...props }, ref) => (
   <TooltipPrimitive.Root
+    ref={ref}
     delayDuration={0}
     {...props}
   />


### PR DESCRIPTION
Should remove some errors when using the tooltip component.