### PR TITLE
fix: ensure refs are forwarded to the component

### DIFF
--- a/src/shadcn/ui/input-group.tsx
+++ b/src/shadcn/ui/input-group.tsx
@@ -132,6 +132,7 @@ const InputGroupInput = React.forwardRef<HTMLInputElement, InputProps>(
   ({className, ...props}, ref) => {
     return (
       <Input
+        ref={ref}
         data-slot="input-group-control"
         className={cn(
           "flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",

--- a/src/shadcn/ui/tooltip.tsx
+++ b/src/shadcn/ui/tooltip.tsx
@@ -7,15 +7,10 @@ import { cn } from "../../utils/cn"
 
 const TooltipProvider = TooltipPrimitive.Provider
 
-const Tooltip = React.forwardRef<
-  React.ComponentRef<typeof TooltipPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>
->(({ ...props }) => (
-  <TooltipPrimitive.Root
-    delayDuration={0}
-    {...props}
-  />
-))
+const Tooltip = (props: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>) => (
+  <TooltipPrimitive.Root delayDuration={0} {...props} />
+)
+
 TooltipPrimitive.Root.displayName = TooltipPrimitive.Root.displayName
 
 const TooltipTrigger = TooltipPrimitive.Trigger
@@ -38,4 +33,3 @@ const TooltipContent = React.forwardRef<
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }
-


### PR DESCRIPTION
Pass refs for InputGroup, and remove ref for Tooltip -> TooltipPrimitive.Root which doesn't have any.
This reduces the errors we see for refs in velum.